### PR TITLE
fix fqdn CNAME writeFileSync

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -69,8 +69,8 @@ function run() {
             core.info(`🏃 Copying ${path.join(currentdir, build_dir)} contents to ${tmpdir}`);
             fs_extra_1.copySync(path.join(currentdir, build_dir), tmpdir);
             if (fqdn) {
-                core.info(`✍️ Writing ${fqdn} domain name to ${path.join(build_dir, 'CNAME')}`);
-                fs.writeFileSync(path.join(build_dir, 'CNAME'), fqdn.trim());
+                core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, build_dir, 'CNAME')}`);
+                fs.writeFileSync(path.join(tmpdir, build_dir, 'CNAME'), fqdn.trim());
             }
             core.info(`🔨 Configuring git committer to be ${committer_name} <${committer_email}>`);
             yield exec.exec('git', ['config', 'user.name', committer_name]);

--- a/lib/main.js
+++ b/lib/main.js
@@ -69,8 +69,8 @@ function run() {
             core.info(`🏃 Copying ${path.join(currentdir, build_dir)} contents to ${tmpdir}`);
             fs_extra_1.copySync(path.join(currentdir, build_dir), tmpdir);
             if (fqdn) {
-                core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, build_dir, 'CNAME')}`);
-                fs.writeFileSync(path.join(tmpdir, build_dir, 'CNAME'), fqdn.trim());
+                core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, 'CNAME')}`);
+                fs.writeFileSync(path.join(tmpdir, 'CNAME'), fqdn.trim());
             }
             core.info(`🔨 Configuring git committer to be ${committer_name} <${committer_email}>`);
             yield exec.exec('git', ['config', 'user.name', committer_name]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,8 +55,8 @@ async function run() {
     copySync(path.join(currentdir, build_dir), tmpdir);
 
     if (fqdn) {
-      core.info(`✍️ Writing ${fqdn} domain name to ${path.join(build_dir, 'CNAME')}`);
-      fs.writeFileSync(path.join(build_dir, 'CNAME'), fqdn.trim());
+      core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, build_dir, 'CNAME')}`);
+      fs.writeFileSync(path.join(tmpdir, build_dir, 'CNAME'), fqdn.trim());
     }
 
     core.info(`🔨 Configuring git committer to be ${committer_name} <${committer_email}>`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,8 +55,8 @@ async function run() {
     copySync(path.join(currentdir, build_dir), tmpdir);
 
     if (fqdn) {
-      core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, build_dir, 'CNAME')}`);
-      fs.writeFileSync(path.join(tmpdir, build_dir, 'CNAME'), fqdn.trim());
+      core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, 'CNAME')}`);
+      fs.writeFileSync(path.join(tmpdir, 'CNAME'), fqdn.trim());
     }
 
     core.info(`🔨 Configuring git committer to be ${committer_name} <${committer_email}>`);


### PR DESCRIPTION
Fixes #30.

When the `fqdn` option is enabled, it tries `writeFileSync`ing the FQDN to `${build_dir}/CNAME` but `${build_dir}` doesn't exist so it errors out. It should be writing the CNAME file to the current working directory (`${tmpdir}`) instead.

I also added `${tmpdir}` to the path join call in order to be explicit about where that file is being written.
