### PR TITLE
fixed git error 'error: failed to push some refs to ...'

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -31,7 +31,7 @@ export async function init(dest: string): Promise<void> {
 }
 
 export async function checkout(branch: string): Promise<void> {
-  await git(['checkout', '--orphan', branch]);
+  await git(['checkout', '-b', branch]);
 }
 
 export async function isDirty(): Promise<boolean> {


### PR DESCRIPTION
I experienced that when you checkout the new `target_branch` with `git checkout --orphan` it will produce the git error `error: failed to push some refs to ...` cause the branch is not really created. Thats why git cannot push it to the remote repo. Therefore you must use `git checkout -b` instead. Than it's working perfect.