### PR TITLE
Add jekyll input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Following inputs can be used as `step.with` keys
 | `author`             | String  | Author name and email address as `Display Name <joe@foo.bar>` (defaults to the GitHub Actions bot user) |
 | `commit_message`     | String  | Commit message (default `Deploy to GitHub pages`)                           |
 | `fqdn`               | String  | Write the given domain name to the CNAME file                               |
+| `jekyll`             | Bool    | Allow Jekyll to build your site (default `true`)                            |
 
 ### environment variables
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
   fqdn:
     description: 'Write the given domain name to the CNAME file'
     required: false
+  jekyll:
+    description: 'Allow Jekyll to build your site'
+    default: 'true'
+    required: false
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1799,6 +1799,7 @@ function run() {
             const author = core.getInput('author') || git.defaults.author;
             const commitMessage = core.getInput('commit_message') || git.defaults.message;
             const fqdn = core.getInput('fqdn');
+            const jekyll = /false/i.test(core.getInput('jekyll'));
             if (!fs.existsSync(buildDir)) {
                 core.setFailed('Build dir does not exist');
                 return;
@@ -1839,6 +1840,10 @@ function run() {
             if (fqdn) {
                 core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, 'CNAME')}`);
                 yield fs.writeFileSync(path.join(tmpdir, 'CNAME'), fqdn.trim());
+            }
+            if (jekyll) {
+                core.info(`🚫 Disabling Jekyll support via ${path.join(tmpdir, '.nojekyll')}`);
+                yield fs.writeFileSync(path.join(tmpdir, '.nojekyll'), '');
             }
             const isDirty = yield git.isDirty();
             core.debug(`isDirty=${isDirty}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ async function run() {
     const author: string = core.getInput('author') || git.defaults.author;
     const commitMessage: string = core.getInput('commit_message') || git.defaults.message;
     const fqdn: string = core.getInput('fqdn');
+    const jekyll: boolean = /false/i.test(core.getInput('jekyll'));
 
     if (!fs.existsSync(buildDir)) {
       core.setFailed('Build dir does not exist');
@@ -61,6 +62,11 @@ async function run() {
     if (fqdn) {
       core.info(`✍️ Writing ${fqdn} domain name to ${path.join(tmpdir, 'CNAME')}`);
       await fs.writeFileSync(path.join(tmpdir, 'CNAME'), fqdn.trim());
+    }
+
+    if (jekyll) {
+      core.info(`🚫 Disabling Jekyll support via ${path.join(tmpdir, '.nojekyll')}`);
+      await fs.writeFileSync(path.join(tmpdir, '.nojekyll'), '');
     }
 
     const isDirty: boolean = await git.isDirty();


### PR DESCRIPTION
GitHub Pages will use Jekyll to build your site by default. This input option allows for this functionality to be disabled. The option is left to `true` by default as setting to `false` will cause the `.nojekyll` file to be written to the output directory.

https://help.github.com/en/github/working-with-github-pages/about-github-pages#static-site-generators