### PR TITLE
Shorten messages about copied files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,10 +60,11 @@ async function run() {
       core.endGroup();
     }
 
-    await core.group(`Copying ${path.join(currentdir, buildDir)} to ${tmpdir}`, async () => {
-      await copy(path.join(currentdir, buildDir), tmpdir, {
-        filter: (src, dest) => {
-          core.info(`${src} => ${dest}`);
+    const sourceDir = path.join(currentdir, buildDir)
+    await core.group(`Copying ${sourceDir} to ${tmpdir}`, async () => {
+      await copy(sourceDir, tmpdir, {
+        filter: (src, dest) => { 
+          core.info(`${src.substring(sourceDir.length+1)}`);
           return true;
         }
       }).catch(error => {


### PR DESCRIPTION
This may prevent messages with many files from being truncated.

https://github.com/abitrolly/fedora-packages-static/runs/2632566525?check_suite_focus=true

I edited it from the web and haven't got time to test this on local checkout. Hope tests will fail if there are any mistakes.